### PR TITLE
Fix wrong size for guild server error icon

### DIFF
--- a/themes/DarkMatter/DarkMatter.theme.css
+++ b/themes/DarkMatter/DarkMatter.theme.css
@@ -328,7 +328,7 @@ textarea {
     background: rgba(0,0,0,0.3);
 }
 
-.guilds-error {
+.guilds-wrapper .guilds-error {
 	width:40px;
 	height:40px;
 	line-height:36px;


### PR DESCRIPTION
When there is an issue with a discord guild server the icon it shows is the incorrect size.  It gets sized 50px x 50px which is the normal size for Discord.  Checking inspector shows that ".guilds-wrapper .guilds-error" is overriding the theme sizing.  Changing this line to match allows it to get proper sizing and line height so that it looks correct with all the other guild icons.